### PR TITLE
Fix release build failure if release is created from GitHub UI.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,5 +19,8 @@ jobs:
       run: zip ${{ env.ARCHIVE }} -r .
     - uses: ncipollo/release-action@v1
       with:
+        allowUpdates: true
+        omitBodyDuringUpdate: true
+        omitNameDuringUpdate: true
         artifacts: ${{ env.ARCHIVE }}
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* Add flags to release action config for updating an existing release.