### PR TITLE
Capture release info when creating release archive.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       run: echo "TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
     - name: Set archive name
       run: echo "ARCHIVE=msab-arts-locator_${{ env.TAG }}.zip" >> $GITHUB_ENV
+    - run: echo "module.exports = { version: '${{ env.TAG }}' };" > release_info.js
     - name: bundle release artifact
       run: zip ${{ env.ARCHIVE }} -r .
     - uses: ncipollo/release-action@v1

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 .yarn
 .pnp.js
 test-report.html
+release_info.js

--- a/src/package.json
+++ b/src/package.json
@@ -24,7 +24,7 @@
     "lint:fix": "eslint --fix . && eslint --fix ./**/*.jsx && stylelint --fix ./**/*.scss",
     "start": "rm -rf dist && npm-run-all -p watch-css start-js",
     "start-js": "yarn codeVersion && MSAB_ENV=dev parcel --no-cache index.pug  --port 5678",
-    "codeVersion": "echo \"module.exports = { version: '$(git describe --tags)' };\" > environments/client/version.js",
+    "codeVersion": "cp -v release_info.js environments/client/version.js || echo \"module.exports = { version: '$(git describe --tags)' };\" > environments/client/version.js",
     "build": "yarn codeVersion && MSAB_ENV=prod parcel build  --no-source-maps index.pug"
   },
   "repository": {


### PR DESCRIPTION
* Avoids `codeVersion` dependency on running in a git repo clone.