### PR TITLE
Improve submit location UX

### DIFF
--- a/src/entities/ArtLocation.js
+++ b/src/entities/ArtLocation.js
@@ -46,18 +46,15 @@ function ArtLocation({ applicationContext, rawArtLocation }) {
     errorMessage: {
       _: 'Location should include a name, street address, city name, zip code, contact name, contact phone, and contact email.',
       properties: {
-        city: 'City should be a string 1 characters long',
-        contactEmail:
-          'Contact e-mail should be a string at least 1 characters long',
-        contactName:
-          'Contact name should be a string at least 1 characters long',
-        contactPhone:
-          'Contact phone should be a string at least 1 characters long',
+        city: 'City',
+        contactEmail: 'Contact e-mail',
+        contactName: 'Contact name',
+        contactPhone: 'Contact phone',
         gresp: 'Please complete the CAPTCHA to submit',
-        name: 'Name should be a string at least 1 characters long',
-        state: 'State should be a string 2 characters long',
-        street: 'Street should be a string at least 1 characters long',
-        zip: 'Zip should be a number at least 5 numbers long',
+        name: 'Name',
+        state: 'State',
+        street: 'Street',
+        zip: 'ZIP',
       },
       type: 'Data should be an object',
     },

--- a/src/package.json
+++ b/src/package.json
@@ -53,7 +53,7 @@
     "bulma": "^0.9.3",
     "cerebral": "^5.1.0",
     "conversions": "^1.5.2",
-    "core-js": "3.15.0",
+    "core-js": "3.15.1",
     "dynamodb-geo": "^0.4.0",
     "file-type": "^16.5.0",
     "format-url": "^1.1.0",

--- a/src/presenter/cerebral/actions/goBackAction.test.js
+++ b/src/presenter/cerebral/actions/goBackAction.test.js
@@ -4,22 +4,21 @@ import { runAction } from 'cerebral/test';
 
 describe('goBackAction', () => {
   it('should call `back` on history', () => {
+    const backMock = jest.fn();
     const mockWindow = {
       history: () => {
         return {
-          back: () => {
-            expect(true).toBeTruthy();
-          },
+          back: backMock,
         };
       },
     };
 
     presenter.providers.humbleWindow = mockWindow;
-    expect.assertions(1);
-    return runAction(goBackAction, {
+    runAction(goBackAction, {
       modules: {
         presenter,
       },
     });
+    expect(backMock).toHaveBeenCalled();
   });
 });

--- a/src/presenter/cerebral/actions/goToHomeAction.js
+++ b/src/presenter/cerebral/actions/goToHomeAction.js
@@ -1,0 +1,3 @@
+export const goToHomeAction = () => {
+  window.location.href = '/';
+};

--- a/src/presenter/cerebral/actions/goToHomeAction.js
+++ b/src/presenter/cerebral/actions/goToHomeAction.js
@@ -1,3 +1,3 @@
-export const goToHomeAction = () => {
-  window.location.href = '/';
+export const goToHomeAction = ({ router }) => {
+  router.route('/');
 };

--- a/src/presenter/cerebral/actions/goToHomeAction.test.js
+++ b/src/presenter/cerebral/actions/goToHomeAction.test.js
@@ -1,0 +1,21 @@
+import { goToHomeAction } from './goToHomeAction';
+import { presenter } from '../../../presenter/presenter';
+import { runAction } from 'cerebral/test';
+
+describe('goToHomeAction', () => {
+  it('should route to /', () => {
+    const mockRouter = {
+      route: path => {
+        expect(path).toEqual('/');
+      },
+    };
+
+    presenter.providers.router = mockRouter;
+    expect.assertions(1);
+    return runAction(goToHomeAction, {
+      modules: {
+        presenter,
+      },
+    });
+  });
+});

--- a/src/presenter/cerebral/actions/resetFormAction.test.js
+++ b/src/presenter/cerebral/actions/resetFormAction.test.js
@@ -13,8 +13,7 @@ describe('resetFormAction', () => {
         },
       },
     };
-    return runAction(resetFormAction, initialState).then(({ state }) =>
-      expect(state.form).toMatchObject(defaultForm()),
-    );
+    const { state } = await runAction(resetFormAction, initialState);
+    expect(state.form).toMatchObject(defaultForm());
   });
 });

--- a/src/presenter/cerebral/actions/submitLocationResultAction.js
+++ b/src/presenter/cerebral/actions/submitLocationResultAction.js
@@ -32,7 +32,14 @@ export const submitLocationResultAction = async ({ get, props, store }) => {
   } else {
     if (props.result && props.result.data) {
       const fullError = JSON.parse(props.result.data);
-      store.set(state.submitLocationMsg, fullError[0].message);
+      store.set(
+        state.submitLocationMsg,
+        'Please complete the following form fields',
+      );
+      store.set(
+        state.submitLocationErrors,
+        fullError.map(error => error.message),
+      );
     } else {
       store.set(state.submitLocationMsg, 'Location Failed to Send.');
     }

--- a/src/presenter/cerebral/actions/submitLocationResultAction.js
+++ b/src/presenter/cerebral/actions/submitLocationResultAction.js
@@ -1,6 +1,11 @@
 import { state } from 'cerebral';
 
-export const submitLocationResultAction = async ({ get, props, store }) => {
+export const submitLocationResultAction = async ({
+  get,
+  path,
+  props,
+  store,
+}) => {
   let response = null;
   let action = null;
 
@@ -28,6 +33,7 @@ export const submitLocationResultAction = async ({ get, props, store }) => {
         `Art Location Successfully ${action}!`,
       );
       store.set(state.form.formDirty, false);
+      return path.success({ page: 'Home' });
     }
   } else {
     if (props.result && props.result.data) {

--- a/src/presenter/cerebral/actions/submitLocationResultAction.js
+++ b/src/presenter/cerebral/actions/submitLocationResultAction.js
@@ -7,18 +7,22 @@ export const submitLocationResultAction = async ({
   store,
 }) => {
   let response = null;
-  let action = null;
+  let successMessage = null;
+  let successDetail = null;
 
+  store.set(state.submitLocationErrors, []);
   if (get(state.form.update.actionType) === 'admin') {
     if (get(state.form.approved)) {
-      action = 'Approved!';
+      successMessage = 'Art Location Successfully Approved!';
     } else {
-      action = 'Unapproved!';
+      successMessage = 'Art Location Successfully Unapproved!';
     }
   } else if (get(state.form.update.actionType === 'update')) {
-    action = 'Updated!';
+    successMessage = 'Thanks for Your Update.';
   } else {
-    action = 'Submitted!';
+    successMessage = 'Thanks for Your Submission';
+    successDetail =
+      'A Minnesota State Arts Board administrator will review your submission before publishing it on the site.';
   }
   if (props.result && props.result.response) {
     if (typeof props.result.response === 'string') {
@@ -28,10 +32,8 @@ export const submitLocationResultAction = async ({
     }
     if (response.message === 'success') {
       store.set(state.submitLocationSuccess, true);
-      store.set(
-        state.submitLocationMsg,
-        `Art Location Successfully ${action}!`,
-      );
+      store.set(state.submitLocationMsg, successMessage);
+      store.set(state.submitLocationMsgDetail, successDetail);
       store.set(state.form.formDirty, false);
       return path.success({ page: 'Home' });
     }
@@ -40,7 +42,11 @@ export const submitLocationResultAction = async ({
       const fullError = JSON.parse(props.result.data);
       store.set(
         state.submitLocationMsg,
-        'Please complete the following form fields',
+        "There's an error submitting the form.",
+      );
+      store.set(
+        state.submitLocationMsgDetail,
+        'Please complete the following form fields:',
       );
       store.set(
         state.submitLocationErrors,

--- a/src/presenter/cerebral/frameworks/humbleBrowser.js
+++ b/src/presenter/cerebral/frameworks/humbleBrowser.js
@@ -1,6 +1,6 @@
 const humbleWindow = {
   history: () => {
-    return history;
+    return window.history;
   },
 };
 module.exports = humbleWindow;

--- a/src/presenter/cerebral/sequences/submitLocationSequence.js
+++ b/src/presenter/cerebral/sequences/submitLocationSequence.js
@@ -1,3 +1,4 @@
+import { routeChangeSequence } from './routeChangeSequence';
 import { submitLocationAction } from '../actions/submitLocationAction';
 import { submitLocationResultAction } from '../actions/submitLocationResultAction';
 import { updateLocationAction } from '../actions/updateLocationAction';
@@ -7,4 +8,5 @@ export const submitLocationSequence = [
   validateLocationAction,
   { submit: [submitLocationAction], update: [updateLocationAction] },
   submitLocationResultAction,
+  { success: [routeChangeSequence] },
 ];

--- a/src/presenter/cerebral/sequences/submitLocationSequence.js
+++ b/src/presenter/cerebral/sequences/submitLocationSequence.js
@@ -1,4 +1,4 @@
-import { routeChangeSequence } from './routeChangeSequence';
+import { goToHomeAction } from '../actions/goToHomeAction';
 import { submitLocationAction } from '../actions/submitLocationAction';
 import { submitLocationResultAction } from '../actions/submitLocationResultAction';
 import { updateLocationAction } from '../actions/updateLocationAction';
@@ -8,5 +8,5 @@ export const submitLocationSequence = [
   validateLocationAction,
   { submit: [submitLocationAction], update: [updateLocationAction] },
   submitLocationResultAction,
-  { success: [routeChangeSequence] },
+  { success: [goToHomeAction] },
 ];

--- a/src/presenter/presenter.js
+++ b/src/presenter/presenter.js
@@ -103,8 +103,9 @@ export const presenter = {
 
     selectImageMsg: '',
 
-    submitLocationFailure: false,
+    submitLocationErrors: [],
 
+    submitLocationFailure: false,
     submitLocationMsg: '',
     submitLocationSuccess: false,
     update: {

--- a/src/presenter/presenter.js
+++ b/src/presenter/presenter.js
@@ -107,6 +107,7 @@ export const presenter = {
 
     submitLocationFailure: false,
     submitLocationMsg: '',
+    submitLocationMsgDetail: '',
     submitLocationSuccess: false,
     update: {
       actionType: '',

--- a/src/sass/main.css
+++ b/src/sass/main.css
@@ -1134,84 +1134,84 @@ a.box:active {
         border-color: transparent;
         color: #946c00; }
   .button.is-danger {
-    background-color: #f14668;
+    background-color: #d8eeee;
     border-color: transparent;
-    color: #fff; }
+    color: rgba(0, 0, 0, 0.7); }
     .button.is-danger:hover, .button.is-danger.is-hovered {
-      background-color: #f03a5f;
+      background-color: #cfeaea;
       border-color: transparent;
-      color: #fff; }
+      color: rgba(0, 0, 0, 0.7); }
     .button.is-danger:focus, .button.is-danger.is-focused {
       border-color: transparent;
-      color: #fff; }
+      color: rgba(0, 0, 0, 0.7); }
       .button.is-danger:focus:not(:active), .button.is-danger.is-focused:not(:active) {
-        box-shadow: 0 0 0 0.125em rgba(241, 70, 104, 0.25); }
+        box-shadow: 0 0 0 0.125em rgba(216, 238, 238, 0.25); }
     .button.is-danger:active, .button.is-danger.is-active {
-      background-color: #ef2e55;
+      background-color: #c6e6e6;
       border-color: transparent;
-      color: #fff; }
+      color: rgba(0, 0, 0, 0.7); }
     .button.is-danger[disabled],
     fieldset[disabled] .button.is-danger {
-      background-color: #f14668;
+      background-color: #d8eeee;
       border-color: transparent;
       box-shadow: none; }
     .button.is-danger.is-inverted {
-      background-color: #fff;
-      color: #f14668; }
+      background-color: rgba(0, 0, 0, 0.7);
+      color: #d8eeee; }
       .button.is-danger.is-inverted:hover, .button.is-danger.is-inverted.is-hovered {
-        background-color: #f2f2f2; }
+        background-color: rgba(0, 0, 0, 0.7); }
       .button.is-danger.is-inverted[disabled],
       fieldset[disabled] .button.is-danger.is-inverted {
-        background-color: #fff;
+        background-color: rgba(0, 0, 0, 0.7);
         border-color: transparent;
         box-shadow: none;
-        color: #f14668; }
+        color: #d8eeee; }
     .button.is-danger.is-loading::after {
-      border-color: transparent transparent #fff #fff !important; }
+      border-color: transparent transparent rgba(0, 0, 0, 0.7) rgba(0, 0, 0, 0.7) !important; }
     .button.is-danger.is-outlined {
       background-color: transparent;
-      border-color: #f14668;
-      color: #f14668; }
+      border-color: #d8eeee;
+      color: #d8eeee; }
       .button.is-danger.is-outlined:hover, .button.is-danger.is-outlined.is-hovered, .button.is-danger.is-outlined:focus, .button.is-danger.is-outlined.is-focused {
-        background-color: #f14668;
-        border-color: #f14668;
-        color: #fff; }
+        background-color: #d8eeee;
+        border-color: #d8eeee;
+        color: rgba(0, 0, 0, 0.7); }
       .button.is-danger.is-outlined.is-loading::after {
-        border-color: transparent transparent #f14668 #f14668 !important; }
+        border-color: transparent transparent #d8eeee #d8eeee !important; }
       .button.is-danger.is-outlined.is-loading:hover::after, .button.is-danger.is-outlined.is-loading.is-hovered::after, .button.is-danger.is-outlined.is-loading:focus::after, .button.is-danger.is-outlined.is-loading.is-focused::after {
-        border-color: transparent transparent #fff #fff !important; }
+        border-color: transparent transparent rgba(0, 0, 0, 0.7) rgba(0, 0, 0, 0.7) !important; }
       .button.is-danger.is-outlined[disabled],
       fieldset[disabled] .button.is-danger.is-outlined {
         background-color: transparent;
-        border-color: #f14668;
+        border-color: #d8eeee;
         box-shadow: none;
-        color: #f14668; }
+        color: #d8eeee; }
     .button.is-danger.is-inverted.is-outlined {
       background-color: transparent;
-      border-color: #fff;
-      color: #fff; }
+      border-color: rgba(0, 0, 0, 0.7);
+      color: rgba(0, 0, 0, 0.7); }
       .button.is-danger.is-inverted.is-outlined:hover, .button.is-danger.is-inverted.is-outlined.is-hovered, .button.is-danger.is-inverted.is-outlined:focus, .button.is-danger.is-inverted.is-outlined.is-focused {
-        background-color: #fff;
-        color: #f14668; }
+        background-color: rgba(0, 0, 0, 0.7);
+        color: #d8eeee; }
       .button.is-danger.is-inverted.is-outlined.is-loading:hover::after, .button.is-danger.is-inverted.is-outlined.is-loading.is-hovered::after, .button.is-danger.is-inverted.is-outlined.is-loading:focus::after, .button.is-danger.is-inverted.is-outlined.is-loading.is-focused::after {
-        border-color: transparent transparent #f14668 #f14668 !important; }
+        border-color: transparent transparent #d8eeee #d8eeee !important; }
       .button.is-danger.is-inverted.is-outlined[disabled],
       fieldset[disabled] .button.is-danger.is-inverted.is-outlined {
         background-color: transparent;
-        border-color: #fff;
+        border-color: rgba(0, 0, 0, 0.7);
         box-shadow: none;
-        color: #fff; }
+        color: rgba(0, 0, 0, 0.7); }
     .button.is-danger.is-light {
-      background-color: #feecf0;
-      color: #cc0f35; }
+      background-color: #f1f9f9;
+      color: #2d6767; }
       .button.is-danger.is-light:hover, .button.is-danger.is-light.is-hovered {
-        background-color: #fde0e6;
+        background-color: #e8f5f5;
         border-color: transparent;
-        color: #cc0f35; }
+        color: #2d6767; }
       .button.is-danger.is-light:active, .button.is-danger.is-light.is-active {
-        background-color: #fcd4dc;
+        background-color: #dff1f1;
         border-color: transparent;
-        color: #cc0f35; }
+        color: #2d6767; }
   .button.is-small {
     font-size: 0.75rem; }
     .button.is-small:not(.is-rounded) {
@@ -1656,11 +1656,11 @@ div.icon-text {
       background-color: #fffaeb;
       color: #946c00; }
   .notification.is-danger {
-    background-color: #f14668;
-    color: #fff; }
+    background-color: #d8eeee;
+    color: rgba(0, 0, 0, 0.7); }
     .notification.is-danger.is-light {
-      background-color: #feecf0;
-      color: #cc0f35; }
+      background-color: #f1f9f9;
+      color: #2d6767; }
 
 .progress {
   -moz-appearance: none;
@@ -1754,13 +1754,13 @@ div.icon-text {
   .progress.is-warning:indeterminate {
     background-image: linear-gradient(to right, #ffe08a 30%, #ededed 30%); }
   .progress.is-danger::-webkit-progress-value {
-    background-color: #f14668; }
+    background-color: #d8eeee; }
   .progress.is-danger::-moz-progress-bar {
-    background-color: #f14668; }
+    background-color: #d8eeee; }
   .progress.is-danger::-ms-fill {
-    background-color: #f14668; }
+    background-color: #d8eeee; }
   .progress.is-danger:indeterminate {
-    background-image: linear-gradient(to right, #f14668 30%, #ededed 30%); }
+    background-image: linear-gradient(to right, #d8eeee 30%, #ededed 30%); }
   .progress:indeterminate {
     animation-duration: 1.5s;
     animation-iteration-count: infinite;
@@ -1846,9 +1846,9 @@ div.icon-text {
       color: rgba(0, 0, 0, 0.7); }
     .table td.is-danger,
     .table th.is-danger {
-      background-color: #f14668;
-      border-color: #f14668;
-      color: #fff; }
+      background-color: #d8eeee;
+      border-color: #d8eeee;
+      color: rgba(0, 0, 0, 0.7); }
     .table td.is-narrow,
     .table th.is-narrow {
       white-space: nowrap;
@@ -2019,11 +2019,11 @@ div.icon-text {
       background-color: #fffaeb;
       color: #946c00; }
   .tag:not(body).is-danger {
-    background-color: #f14668;
-    color: #fff; }
+    background-color: #d8eeee;
+    color: rgba(0, 0, 0, 0.7); }
     .tag:not(body).is-danger.is-light {
-      background-color: #feecf0;
-      color: #cc0f35; }
+      background-color: #f1f9f9;
+      color: #2d6767; }
   .tag:not(body).is-normal {
     font-size: 0.75rem; }
   .tag:not(body).is-medium {
@@ -2254,9 +2254,9 @@ a.tag:hover {
     .is-warning.input:focus, .is-warning.textarea:focus, .is-warning.is-focused.input, .is-warning.is-focused.textarea, .is-warning.input:active, .is-warning.textarea:active, .is-warning.is-active.input, .is-warning.is-active.textarea {
       box-shadow: 0 0 0 0.125em rgba(255, 224, 138, 0.25); }
   .is-danger.input, .is-danger.textarea {
-    border-color: #f14668; }
+    border-color: #d8eeee; }
     .is-danger.input:focus, .is-danger.textarea:focus, .is-danger.is-focused.input, .is-danger.is-focused.textarea, .is-danger.input:active, .is-danger.textarea:active, .is-danger.is-active.input, .is-danger.is-active.textarea {
-      box-shadow: 0 0 0 0.125em rgba(241, 70, 104, 0.25); }
+      box-shadow: 0 0 0 0.125em rgba(216, 238, 238, 0.25); }
   .is-small.input, .is-small.textarea {
     border-radius: 2px;
     font-size: 0.75rem; }
@@ -2424,13 +2424,13 @@ a.tag:hover {
     .select.is-warning select:focus, .select.is-warning select.is-focused, .select.is-warning select:active, .select.is-warning select.is-active {
       box-shadow: 0 0 0 0.125em rgba(255, 224, 138, 0.25); }
   .select.is-danger:not(:hover)::after {
-    border-color: #f14668; }
+    border-color: #d8eeee; }
   .select.is-danger select {
-    border-color: #f14668; }
+    border-color: #d8eeee; }
     .select.is-danger select:hover, .select.is-danger select.is-hovered {
-      border-color: #ef2e55; }
+      border-color: #c6e6e6; }
     .select.is-danger select:focus, .select.is-danger select.is-focused, .select.is-danger select:active, .select.is-danger select.is-active {
-      box-shadow: 0 0 0 0.125em rgba(241, 70, 104, 0.25); }
+      box-shadow: 0 0 0 0.125em rgba(216, 238, 238, 0.25); }
   .select.is-small {
     border-radius: 2px;
     font-size: 0.75rem; }
@@ -2607,21 +2607,21 @@ a.tag:hover {
     border-color: transparent;
     color: rgba(0, 0, 0, 0.7); }
   .file.is-danger .file-cta {
-    background-color: #f14668;
+    background-color: #d8eeee;
     border-color: transparent;
-    color: #fff; }
+    color: rgba(0, 0, 0, 0.7); }
   .file.is-danger:hover .file-cta, .file.is-danger.is-hovered .file-cta {
-    background-color: #f03a5f;
+    background-color: #cfeaea;
     border-color: transparent;
-    color: #fff; }
+    color: rgba(0, 0, 0, 0.7); }
   .file.is-danger:focus .file-cta, .file.is-danger.is-focused .file-cta {
     border-color: transparent;
-    box-shadow: 0 0 0.5em rgba(241, 70, 104, 0.25);
-    color: #fff; }
+    box-shadow: 0 0 0.5em rgba(216, 238, 238, 0.25);
+    color: rgba(0, 0, 0, 0.7); }
   .file.is-danger:active .file-cta, .file.is-danger.is-active .file-cta {
-    background-color: #ef2e55;
+    background-color: #c6e6e6;
     border-color: transparent;
-    color: #fff; }
+    color: rgba(0, 0, 0, 0.7); }
   .file.is-small {
     font-size: 0.75rem; }
   .file.is-normal {
@@ -2781,7 +2781,7 @@ a.tag:hover {
   .help.is-warning {
     color: #ffe08a; }
   .help.is-danger {
-    color: #f14668; }
+    color: #d8eeee; }
 
 .field:not(:last-child) {
   margin-bottom: 0.75rem; }
@@ -3403,13 +3403,13 @@ button.dropdown-item {
       border-color: #ffe08a;
       color: #946c00; }
   .message.is-danger {
-    background-color: #feecf0; }
+    background-color: #f1f9f9; }
     .message.is-danger .message-header {
-      background-color: #f14668;
-      color: #fff; }
+      background-color: #d8eeee;
+      color: rgba(0, 0, 0, 0.7); }
     .message.is-danger .message-body {
-      border-color: #f14668;
-      color: #cc0f35; }
+      border-color: #d8eeee;
+      color: #2d6767; }
 
 .message-header {
   align-items: center;
@@ -3935,27 +3935,27 @@ button.dropdown-item {
         background-color: #ffe08a;
         color: rgba(0, 0, 0, 0.7); } }
   .navbar.is-danger {
-    background-color: #f14668;
-    color: #fff; }
+    background-color: #d8eeee;
+    color: rgba(0, 0, 0, 0.7); }
     .navbar.is-danger .navbar-brand > .navbar-item,
     .navbar.is-danger .navbar-brand .navbar-link {
-      color: #fff; }
+      color: rgba(0, 0, 0, 0.7); }
     .navbar.is-danger .navbar-brand > a.navbar-item:focus, .navbar.is-danger .navbar-brand > a.navbar-item:hover, .navbar.is-danger .navbar-brand > a.navbar-item.is-active,
     .navbar.is-danger .navbar-brand .navbar-link:focus,
     .navbar.is-danger .navbar-brand .navbar-link:hover,
     .navbar.is-danger .navbar-brand .navbar-link.is-active {
-      background-color: #ef2e55;
-      color: #fff; }
+      background-color: #c6e6e6;
+      color: rgba(0, 0, 0, 0.7); }
     .navbar.is-danger .navbar-brand .navbar-link::after {
-      border-color: #fff; }
+      border-color: rgba(0, 0, 0, 0.7); }
     .navbar.is-danger .navbar-burger {
-      color: #fff; }
+      color: rgba(0, 0, 0, 0.7); }
     @media screen and (min-width: 1024px) {
       .navbar.is-danger .navbar-start > .navbar-item,
       .navbar.is-danger .navbar-start .navbar-link,
       .navbar.is-danger .navbar-end > .navbar-item,
       .navbar.is-danger .navbar-end .navbar-link {
-        color: #fff; }
+        color: rgba(0, 0, 0, 0.7); }
       .navbar.is-danger .navbar-start > a.navbar-item:focus, .navbar.is-danger .navbar-start > a.navbar-item:hover, .navbar.is-danger .navbar-start > a.navbar-item.is-active,
       .navbar.is-danger .navbar-start .navbar-link:focus,
       .navbar.is-danger .navbar-start .navbar-link:hover,
@@ -3966,19 +3966,19 @@ button.dropdown-item {
       .navbar.is-danger .navbar-end .navbar-link:focus,
       .navbar.is-danger .navbar-end .navbar-link:hover,
       .navbar.is-danger .navbar-end .navbar-link.is-active {
-        background-color: #ef2e55;
-        color: #fff; }
+        background-color: #c6e6e6;
+        color: rgba(0, 0, 0, 0.7); }
       .navbar.is-danger .navbar-start .navbar-link::after,
       .navbar.is-danger .navbar-end .navbar-link::after {
-        border-color: #fff; }
+        border-color: rgba(0, 0, 0, 0.7); }
       .navbar.is-danger .navbar-item.has-dropdown:focus .navbar-link,
       .navbar.is-danger .navbar-item.has-dropdown:hover .navbar-link,
       .navbar.is-danger .navbar-item.has-dropdown.is-active .navbar-link {
-        background-color: #ef2e55;
-        color: #fff; }
+        background-color: #c6e6e6;
+        color: rgba(0, 0, 0, 0.7); }
       .navbar.is-danger .navbar-dropdown a.navbar-item.is-active {
-        background-color: #f14668;
-        color: #fff; } }
+        background-color: #d8eeee;
+        color: rgba(0, 0, 0, 0.7); } }
   .navbar > .container {
     align-items: stretch;
     display: flex;
@@ -4512,12 +4512,12 @@ a.navbar-item,
   .panel.is-warning .panel-block.is-active .panel-icon {
     color: #ffe08a; }
   .panel.is-danger .panel-heading {
-    background-color: #f14668;
-    color: #fff; }
+    background-color: #d8eeee;
+    color: rgba(0, 0, 0, 0.7); }
   .panel.is-danger .panel-tabs a.is-active {
-    border-bottom-color: #f14668; }
+    border-bottom-color: #d8eeee; }
   .panel.is-danger .panel-block.is-active .panel-icon {
-    color: #f14668; }
+    color: #d8eeee; }
 
 .panel-tabs:not(:last-child),
 .panel-block:not(:last-child) {
@@ -6067,31 +6067,31 @@ a.has-text-warning-dark:hover, a.has-text-warning-dark:focus {
   background-color: #946c00 !important; }
 
 .has-text-danger {
-  color: #f14668 !important; }
+  color: #d8eeee !important; }
 
 a.has-text-danger:hover, a.has-text-danger:focus {
-  color: #ee1742 !important; }
+  color: #b4dfdf !important; }
 
 .has-background-danger {
-  background-color: #f14668 !important; }
+  background-color: #d8eeee !important; }
 
 .has-text-danger-light {
-  color: #feecf0 !important; }
+  color: #f1f9f9 !important; }
 
 a.has-text-danger-light:hover, a.has-text-danger-light:focus {
-  color: #fabdc9 !important; }
+  color: #cde9e9 !important; }
 
 .has-background-danger-light {
-  background-color: #feecf0 !important; }
+  background-color: #f1f9f9 !important; }
 
 .has-text-danger-dark {
-  color: #cc0f35 !important; }
+  color: #2d6767 !important; }
 
 a.has-text-danger-dark:hover, a.has-text-danger-dark:focus {
-  color: #ee2049 !important; }
+  color: #3c8b8b !important; }
 
 .has-background-danger-dark {
-  background-color: #cc0f35 !important; }
+  background-color: #2d6767 !important; }
 
 .has-text-black-bis {
   color: #121212 !important; }
@@ -7727,50 +7727,50 @@ a.has-text-danger-dark:hover, a.has-text-danger-dark:focus {
         .hero.is-warning.is-bold .navbar-menu {
           background-image: linear-gradient(141deg, #ffb657 0%, #ffe08a 71%, #fff6a3 100%); } }
   .hero.is-danger {
-    background-color: #f14668;
-    color: #fff; }
+    background-color: #d8eeee;
+    color: rgba(0, 0, 0, 0.7); }
     .hero.is-danger a:not(.button):not(.dropdown-item):not(.tag):not(.pagination-link.is-current),
     .hero.is-danger strong {
       color: inherit; }
     .hero.is-danger .title {
-      color: #fff; }
+      color: rgba(0, 0, 0, 0.7); }
     .hero.is-danger .subtitle {
-      color: rgba(255, 255, 255, 0.9); }
+      color: rgba(0, 0, 0, 0.9); }
       .hero.is-danger .subtitle a:not(.button),
       .hero.is-danger .subtitle strong {
-        color: #fff; }
+        color: rgba(0, 0, 0, 0.7); }
     @media screen and (max-width: 1023px) {
       .hero.is-danger .navbar-menu {
-        background-color: #f14668; } }
+        background-color: #d8eeee; } }
     .hero.is-danger .navbar-item,
     .hero.is-danger .navbar-link {
-      color: rgba(255, 255, 255, 0.7); }
+      color: rgba(0, 0, 0, 0.7); }
     .hero.is-danger a.navbar-item:hover, .hero.is-danger a.navbar-item.is-active,
     .hero.is-danger .navbar-link:hover,
     .hero.is-danger .navbar-link.is-active {
-      background-color: #ef2e55;
-      color: #fff; }
+      background-color: #c6e6e6;
+      color: rgba(0, 0, 0, 0.7); }
     .hero.is-danger .tabs a {
-      color: #fff;
+      color: rgba(0, 0, 0, 0.7);
       opacity: 0.9; }
       .hero.is-danger .tabs a:hover {
         opacity: 1; }
     .hero.is-danger .tabs li.is-active a {
-      color: #f14668 !important;
+      color: #d8eeee !important;
       opacity: 1; }
     .hero.is-danger .tabs.is-boxed a, .hero.is-danger .tabs.is-toggle a {
-      color: #fff; }
+      color: rgba(0, 0, 0, 0.7); }
       .hero.is-danger .tabs.is-boxed a:hover, .hero.is-danger .tabs.is-toggle a:hover {
         background-color: rgba(10, 10, 10, 0.1); }
     .hero.is-danger .tabs.is-boxed li.is-active a, .hero.is-danger .tabs.is-boxed li.is-active a:hover, .hero.is-danger .tabs.is-toggle li.is-active a, .hero.is-danger .tabs.is-toggle li.is-active a:hover {
-      background-color: #fff;
-      border-color: #fff;
-      color: #f14668; }
+      background-color: rgba(0, 0, 0, 0.7);
+      border-color: rgba(0, 0, 0, 0.7);
+      color: #d8eeee; }
     .hero.is-danger.is-bold {
-      background-image: linear-gradient(141deg, #fa0a62 0%, #f14668 71%, #f7595f 100%); }
+      background-image: linear-gradient(141deg, #afe4db 0%, #d8eeee 71%, #e9f4f7 100%); }
       @media screen and (max-width: 768px) {
         .hero.is-danger.is-bold .navbar-menu {
-          background-image: linear-gradient(141deg, #fa0a62 0%, #f14668 71%, #f7595f 100%); } }
+          background-image: linear-gradient(141deg, #afe4db 0%, #d8eeee 71%, #e9f4f7 100%); } }
   .hero.is-small .hero-body {
     padding: 1.5rem; }
   @media screen and (min-width: 769px), print {

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -6,6 +6,7 @@ $primary: #217575;
 $teal: #acdcdc;
 $light-teal: #d8eeee;
 $msab-blue: #2a4ea5;
+$danger: $light-teal;
 
 @import '../node_modules/bulma/bulma.sass';
 

--- a/src/views/Alerts.jsx
+++ b/src/views/Alerts.jsx
@@ -1,4 +1,4 @@
-import { Container, Notification, Section } from 'bloomer';
+import { Section, Notification as div } from 'bloomer';
 import { connect } from '@cerebral/react';
 import { state } from 'cerebral';
 import React, { useEffect, useRef } from 'react';
@@ -8,8 +8,10 @@ export const Alerts = connect(
     failure: state.submitLocationFailure,
     submitErrors: state.submitLocationErrors,
     submitMsg: state.submitLocationMsg,
+    submitMsgDetail: state.submitLocationMsgDetail,
+    success: state.submitLocationSuccess,
   },
-  ({ failure, submitErrors, submitMsg }) => {
+  ({ failure, submitErrors, submitMsg, submitMsgDetail, success }) => {
     const notificationRef = useRef(null);
     useEffect(() => {
       const notification = notificationRef.current;
@@ -20,20 +22,18 @@ export const Alerts = connect(
     });
     return (
       <>
-        {failure && (
+        {(failure || success) && (
           <div ref={notificationRef}>
             <Section className="hero is-small is-danger">
-              <Notification isColor="danger">
-                <p className="msab-has-text-grey-bold is-size-5">
-                  There&apos;s an error submitting the form.
+              <div>
+                <p className="msab-has-text-grey is-size-5">{submitMsg}</p>
+                <p className="msab-has-text-grey is-size-6">
+                  {submitMsgDetail}
                 </p>
-                {submitErrors && (
-                  <p className="msab-has-text-grey is-size-6">{submitMsg}</p>
-                )}
                 {submitErrors.map((errorMsg, i) => {
                   return <li key={i}>{errorMsg}</li>;
                 })}
-              </Notification>
+              </div>
             </Section>
           </div>
         )}

--- a/src/views/Alerts.jsx
+++ b/src/views/Alerts.jsx
@@ -1,0 +1,33 @@
+import { Container, Notification, Section } from 'bloomer';
+import { connect } from '@cerebral/react';
+import { state } from 'cerebral';
+import React from 'react';
+
+export const Alerts = connect(
+  {
+    failure: state.submitLocationFailure,
+    submitErrors: state.submitLocationErrors,
+    submitMsg: state.submitLocationMsg,
+  },
+  ({ failure, submitErrors, submitMsg }) => {
+    return (
+      <Container>
+        {failure && (
+          <Section className="hero is-small is-danger">
+            <Notification isColor="danger">
+              <p className="msab-has-text-grey-bold is-size-5">
+                There&apos;s an error submitting the form.
+              </p>
+              {submitErrors && (
+                <p className="msab-has-text-grey is-size-6">{submitMsg}</p>
+              )}
+              {submitErrors.map((errorMsg, i) => {
+                return <li key={i}>{errorMsg}</li>;
+              })}
+            </Notification>
+          </Section>
+        )}
+      </Container>
+    );
+  },
+);

--- a/src/views/Alerts.jsx
+++ b/src/views/Alerts.jsx
@@ -1,4 +1,4 @@
-import { Section, Notification as div } from 'bloomer';
+import { Section } from 'bloomer';
 import { connect } from '@cerebral/react';
 import { state } from 'cerebral';
 import React, { useEffect, useRef } from 'react';

--- a/src/views/Alerts.jsx
+++ b/src/views/Alerts.jsx
@@ -30,8 +30,8 @@ export const Alerts = connect(
                 <p className="msab-has-text-grey is-size-6">
                   {submitMsgDetail}
                 </p>
-                {submitErrors.map((errorMsg, i) => {
-                  return <li key={i}>{errorMsg}</li>;
+                {submitErrors.map(errorMsg => {
+                  return <li key={errorMsg}>{errorMsg}</li>;
                 })}
               </div>
             </Section>

--- a/src/views/Alerts.jsx
+++ b/src/views/Alerts.jsx
@@ -1,7 +1,7 @@
 import { Container, Notification, Section } from 'bloomer';
 import { connect } from '@cerebral/react';
 import { state } from 'cerebral';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 
 export const Alerts = connect(
   {
@@ -10,24 +10,34 @@ export const Alerts = connect(
     submitMsg: state.submitLocationMsg,
   },
   ({ failure, submitErrors, submitMsg }) => {
+    const notificationRef = useRef(null);
+    useEffect(() => {
+      const notification = notificationRef.current;
+      if (notification) {
+        const top = notificationRef.current.offsetTop;
+        window.scrollTo(0, top);
+      }
+    });
     return (
-      <Container>
+      <>
         {failure && (
-          <Section className="hero is-small is-danger">
-            <Notification isColor="danger">
-              <p className="msab-has-text-grey-bold is-size-5">
-                There&apos;s an error submitting the form.
-              </p>
-              {submitErrors && (
-                <p className="msab-has-text-grey is-size-6">{submitMsg}</p>
-              )}
-              {submitErrors.map((errorMsg, i) => {
-                return <li key={i}>{errorMsg}</li>;
-              })}
-            </Notification>
-          </Section>
+          <div ref={notificationRef}>
+            <Section className="hero is-small is-danger">
+              <Notification isColor="danger">
+                <p className="msab-has-text-grey-bold is-size-5">
+                  There&apos;s an error submitting the form.
+                </p>
+                {submitErrors && (
+                  <p className="msab-has-text-grey is-size-6">{submitMsg}</p>
+                )}
+                {submitErrors.map((errorMsg, i) => {
+                  return <li key={i}>{errorMsg}</li>;
+                })}
+              </Notification>
+            </Section>
+          </div>
         )}
-      </Container>
+      </>
     );
   },
 );

--- a/src/views/Curate.jsx
+++ b/src/views/Curate.jsx
@@ -5,10 +5,10 @@ import React from 'react';
 
 export const Curate = connect({}, () => {
   return (
-    <React.Fragment>
+    <>
       <AppHeader />
       <span>Curate goes here</span>
       <Foot />
-    </React.Fragment>
+    </>
   );
 });

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -6,11 +6,11 @@ import { SearchByCity } from './SearchByCity';
 import React from 'react';
 
 export const Home = () => (
-  <React.Fragment>
+  <>
     <AppHeader />
     <Alerts />
     <SearchByCity />
     <ResultsList />
     <Foot />
-  </React.Fragment>
+  </>
 );

--- a/src/views/Home.jsx
+++ b/src/views/Home.jsx
@@ -1,3 +1,4 @@
+import { Alerts } from './Alerts';
 import { AppHeader } from './Header';
 import { Foot } from './Footer';
 import { ResultsList } from './ResultsList';
@@ -7,6 +8,7 @@ import React from 'react';
 export const Home = () => (
   <React.Fragment>
     <AppHeader />
+    <Alerts />
     <SearchByCity />
     <ResultsList />
     <Foot />

--- a/src/views/LocationInput.jsx
+++ b/src/views/LocationInput.jsx
@@ -3,9 +3,9 @@ import { Foot } from './Footer';
 import { LocationInputForm } from './LocationInputForm';
 import React from 'react';
 export const LocationInput = () => (
-  <React.Fragment>
+  <>
     <AppHeader />
     <LocationInputForm />
     <Foot />
-  </React.Fragment>
+  </>
 );

--- a/src/views/LocationInput.jsx
+++ b/src/views/LocationInput.jsx
@@ -1,31 +1,11 @@
 import { AppHeader } from './Header';
-import { Container, Notification } from 'bloomer';
 import { Foot } from './Footer';
 import { LocationInputForm } from './LocationInputForm';
-import { connect } from '@cerebral/react';
-import { state } from 'cerebral';
 import React from 'react';
-export const LocationInput = connect(
-  {
-    failure: state.submitLocationFailure,
-    submitMsg: state.submitLocationMsg,
-    success: state.submitLocationSuccess,
-  },
-  ({ failure, submitMsg, success }) => {
-    let color = success ? 'success' : 'danger';
-    return (
-      <React.Fragment>
-        <AppHeader />
-        <LocationInputForm />
-        {(success || failure) && (
-          <Container>
-            <Notification isColor={color}>
-              <h1 className="location-name">{submitMsg}</h1>
-            </Notification>
-          </Container>
-        )}
-        <Foot />
-      </React.Fragment>
-    );
-  },
+export const LocationInput = () => (
+  <React.Fragment>
+    <AppHeader />
+    <LocationInputForm />
+    <Foot />
+  </React.Fragment>
 );

--- a/src/views/LocationInputForm.jsx
+++ b/src/views/LocationInputForm.jsx
@@ -1,3 +1,4 @@
+import { Alerts } from './Alerts';
 import {
   Button,
   Checkbox,
@@ -47,387 +48,395 @@ export const LocationInputForm = connect(
     };
 
     return (
-      <Section className="msab-section-form">
-        <Container>
-          <Title className="msab-has-text-purple" isSize={3}>
-            Submit Your Arts Location
-          </Title>
-          <Subtitle className="msab-has-text-grey" isSize={5}>
-            Fill out this form and a Minnesota State Arts Board administrator
-            will review it before publishing.
-          </Subtitle>
-          <Subtitle className="msab-has-text-grey-bold" isSize={6}>
-            * All fields required unless otherwise noted
-          </Subtitle>
-          <Title className="msab-has-text-purple" isSize={4}>
-            Your Location
-          </Title>
-          <form noValidate className="search" id="add-location-form">
-            <Field>
-              <Label className="msab-has-text-grey" htmlFor="name">
-                Name
-              </Label>
-              <Subtitle className="msab-has-text-grey-small">
-                How do you want people to know and find you? (e.g., your legal
-                name, your publicity name, a DBA, a pen name, etc.)
-              </Subtitle>
-              <Control className="text-field">
-                <Input
-                  id="name"
-                  name="name"
-                  type="text"
-                  value={form.name || ''}
-                  onChange={e => {
-                    updateFormValueSequence({
-                      key: e.target.name,
-                      value: e.target.value,
-                    });
-                  }}
-                />
-              </Control>
-            </Field>
-            <Field>
-              <Label className="msab-has-text-grey" htmlFor="street">
-                Street Address
-              </Label>
-              <Subtitle className="msab-has-text-grey-small">
-                Where do you want people to find you and potentially visit?
-                (e.g., a performance venue, your studio, retail location, etc.)
-              </Subtitle>
-              <Control className="text-field">
-                <Input
-                  id="street"
-                  name="street"
-                  type="text"
-                  value={form.street || ''}
-                  onChange={e => {
-                    updateFormValueSequence({
-                      key: e.target.name,
-                      value: e.target.value,
-                    });
-                  }}
-                />
-              </Control>
-            </Field>
-            <Field>
-              <Label className="msab-has-text-grey" htmlFor="city">
-                Town/City
-              </Label>
-              <Control className="text-field">
-                <Input
-                  id="city"
-                  name="city"
-                  type="text"
-                  value={form.city || ''}
-                  onChange={e => {
-                    updateFormValueSequence({
-                      key: e.target.name,
-                      value: e.target.value,
-                    });
-                  }}
-                />
-              </Control>
-            </Field>
-            <Field>
-              <Label className="msab-has-text-grey" htmlFor="zip">
-                ZIP
-              </Label>
-              <Control className="text-field">
-                <Input
-                  id="zip"
-                  name="zip"
-                  type="number"
-                  value={form.zip || ''}
-                  onChange={e => {
-                    updateFormValueSequence({
-                      key: e.target.name,
-                      value: e.target.value,
-                    });
-                  }}
-                />
-              </Control>
-            </Field>
-            <Field>
-              <Label className="msab-has-text-grey" htmlFor="website">
-                Web Site (optional)
-              </Label>
-              <Control className="text-field">
-                <Input
-                  id="website"
-                  name="website"
-                  type="text"
-                  value={form.website || ''}
-                  onChange={e => {
-                    updateFormValueSequence({
-                      key: e.target.name,
-                      value: e.target.value,
-                    });
-                  }}
-                />
-              </Control>
-            </Field>
-            <Field>
-              <Label className="msab-has-text-grey" htmlFor="description">
-                Brief Description (optional - max 250 characters)
-              </Label>
-              <Subtitle className="msab-has-text-grey-small">
-                What do you want people to know about you? (e.g., mission
-                statement, description of your art, what you offer, etc.)
-              </Subtitle>
-              <Control className="text-field">
-                <TextArea
-                  id="description"
-                  maxLength="250"
-                  name="description"
-                  value={form.description || ''}
-                  onChange={e => {
-                    updateFormValueSequence({
-                      key: e.target.name,
-                      value: e.target.value,
-                    });
-                  }}
-                />
-              </Control>
-            </Field>
-            <span className="label msab-has-text-grey">Type</span>
-            <Subtitle className="msab-has-text-grey" isSize={6}>
-              (Select up to three that apply)
+      <Container>
+        <Section className="msab-section-form">
+          <Container>
+            <Title className="msab-has-text-purple" isSize={3}>
+              Submit Your Arts Location
+            </Title>
+            <Subtitle className="msab-has-text-grey" isSize={5}>
+              Fill out this form and a Minnesota State Arts Board administrator
+              will review it before publishing.
             </Subtitle>
-            {Object.entries(form.category).map(([catKey, value]) => {
-              return (
-                <Field key={categories[catKey]}>
+            <Subtitle className="msab-has-text-grey-bold" isSize={6}>
+              * All fields required unless otherwise noted
+            </Subtitle>
+          </Container>
+        </Section>
+        <Alerts />
+        <Section className="msab-section-form">
+          <Container>
+            <Title className="msab-has-text-purple" isSize={4}>
+              Your Location
+            </Title>
+            <form noValidate className="search" id="add-location-form">
+              <Field>
+                <Label className="msab-has-text-grey" htmlFor="name">
+                  Name
+                </Label>
+                <Subtitle className="msab-has-text-grey-small">
+                  How do you want people to know and find you? (e.g., your legal
+                  name, your publicity name, a DBA, a pen name, etc.)
+                </Subtitle>
+                <Control className="text-field">
+                  <Input
+                    id="name"
+                    name="name"
+                    type="text"
+                    value={form.name || ''}
+                    onChange={e => {
+                      updateFormValueSequence({
+                        key: e.target.name,
+                        value: e.target.value,
+                      });
+                    }}
+                  />
+                </Control>
+              </Field>
+              <Field>
+                <Label className="msab-has-text-grey" htmlFor="street">
+                  Street Address
+                </Label>
+                <Subtitle className="msab-has-text-grey-small">
+                  Where do you want people to find you and potentially visit?
+                  (e.g., a performance venue, your studio, retail location,
+                  etc.)
+                </Subtitle>
+                <Control className="text-field">
+                  <Input
+                    id="street"
+                    name="street"
+                    type="text"
+                    value={form.street || ''}
+                    onChange={e => {
+                      updateFormValueSequence({
+                        key: e.target.name,
+                        value: e.target.value,
+                      });
+                    }}
+                  />
+                </Control>
+              </Field>
+              <Field>
+                <Label className="msab-has-text-grey" htmlFor="city">
+                  Town/City
+                </Label>
+                <Control className="text-field">
+                  <Input
+                    id="city"
+                    name="city"
+                    type="text"
+                    value={form.city || ''}
+                    onChange={e => {
+                      updateFormValueSequence({
+                        key: e.target.name,
+                        value: e.target.value,
+                      });
+                    }}
+                  />
+                </Control>
+              </Field>
+              <Field>
+                <Label className="msab-has-text-grey" htmlFor="zip">
+                  ZIP
+                </Label>
+                <Control className="text-field">
+                  <Input
+                    id="zip"
+                    name="zip"
+                    type="number"
+                    value={form.zip || ''}
+                    onChange={e => {
+                      updateFormValueSequence({
+                        key: e.target.name,
+                        value: e.target.value,
+                      });
+                    }}
+                  />
+                </Control>
+              </Field>
+              <Field>
+                <Label className="msab-has-text-grey" htmlFor="website">
+                  Web Site (optional)
+                </Label>
+                <Control className="text-field">
+                  <Input
+                    id="website"
+                    name="website"
+                    type="text"
+                    value={form.website || ''}
+                    onChange={e => {
+                      updateFormValueSequence({
+                        key: e.target.name,
+                        value: e.target.value,
+                      });
+                    }}
+                  />
+                </Control>
+              </Field>
+              <Field>
+                <Label className="msab-has-text-grey" htmlFor="description">
+                  Brief Description (optional - max 250 characters)
+                </Label>
+                <Subtitle className="msab-has-text-grey-small">
+                  What do you want people to know about you? (e.g., mission
+                  statement, description of your art, what you offer, etc.)
+                </Subtitle>
+                <Control className="text-field">
+                  <TextArea
+                    id="description"
+                    maxLength="250"
+                    name="description"
+                    value={form.description || ''}
+                    onChange={e => {
+                      updateFormValueSequence({
+                        key: e.target.name,
+                        value: e.target.value,
+                      });
+                    }}
+                  />
+                </Control>
+              </Field>
+              <span className="label msab-has-text-grey">Type</span>
+              <Subtitle className="msab-has-text-grey" isSize={6}>
+                (Select up to three that apply)
+              </Subtitle>
+              {Object.entries(form.category).map(([catKey, value]) => {
+                return (
+                  <Field key={categories[catKey]}>
+                    <Control>
+                      <Checkbox
+                        checked={value || false}
+                        name={catKey}
+                        onChange={e => {
+                          updateFormValueSequence({
+                            key: `category.${catKey}`,
+                            value: e.target.checked,
+                          });
+                        }}
+                      >
+                        <span className="msab-has-text-grey margin-left-10">
+                          {categories[catKey]}
+                        </span>
+                      </Checkbox>
+                    </Control>
+                  </Field>
+                );
+              })}
+              <Field className="msab-margin-top">
+                <Label className="msab-has-text-grey" htmlFor="image">
+                  Location Image (optional - max size 1 MB)
+                </Label>
+                <Subtitle className="msab-has-text-grey-small">
+                  Please choose an image less than 1MB in size and within the
+                  file types supported: GIF, JPG/JPEG, PNG
+                </Subtitle>
+                <Control>
+                  <input
+                    id="image"
+                    name="image"
+                    type="file"
+                    onChange={e => {
+                      setImageSequence({
+                        image: e.target.files[0],
+                      });
+                    }}
+                  />
+                </Control>
+                {form.imageURL && !form.base64Image && (
+                  <Control>
+                    <img src={form.imageURL} />
+                  </Control>
+                )}
+              </Field>
+              {imgFailure && (
+                <Notification isColor="danger">{imgMsg}</Notification>
+              )}
+              <br />
+              <Title className="msab-has-text-purple" isSize={4}>
+                Contact Information
+              </Title>
+              <Subtitle className="msab-has-text-grey" isSize={5}>
+                (For internal use only, won’t be published on site)
+              </Subtitle>
+              <Field>
+                <Label className="msab-has-text-grey" htmlFor="contactName">
+                  Contact Name
+                </Label>
+                <Control className="text-field">
+                  <Input
+                    id="contactName"
+                    name="contactName"
+                    type="text"
+                    value={form.contactName || ''}
+                    onChange={e => {
+                      updateFormValueSequence({
+                        key: e.target.name,
+                        value: e.target.value,
+                      });
+                    }}
+                  />
+                </Control>
+              </Field>
+              <Field>
+                <Label className="msab-has-text-grey" htmlFor="contactEmail">
+                  Contact E-mail
+                </Label>
+                <Control className="text-field">
+                  <Input
+                    id="contactEmail"
+                    name="contactEmail"
+                    type="text"
+                    value={form.contactEmail || ''}
+                    onChange={e => {
+                      updateFormValueSequence({
+                        key: e.target.name,
+                        value: e.target.value,
+                      });
+                    }}
+                  />
+                </Control>
+              </Field>
+              <Field>
+                <Label className="msab-has-text-grey" htmlFor="contactPhone">
+                  Contact Phone
+                </Label>
+                <Control className="text-field">
+                  <Input
+                    id="contactPhone"
+                    name="contactPhone"
+                    type="text"
+                    value={form.contactPhone || ''}
+                    onChange={e => {
+                      updateFormValueSequence({
+                        key: e.target.name,
+                        value: e.target.value,
+                      });
+                    }}
+                  />
+                </Control>
+              </Field>
+              {locationFormButtonsHelper.showSubmit && (
+                <Field>
                   <Control>
                     <Checkbox
-                      checked={value || false}
-                      name={catKey}
+                      id="tos"
+                      name="ToS"
                       onChange={e => {
                         updateFormValueSequence({
-                          key: `category.${catKey}`,
+                          key: 'ToS',
                           value: e.target.checked,
                         });
                       }}
                     >
                       <span className="msab-has-text-grey margin-left-10">
-                        {categories[catKey]}
+                        I agree to the{' '}
+                        <a href="tos" target="_blank">
+                          terms of service
+                        </a>
                       </span>
                     </Checkbox>
                   </Control>
                 </Field>
-              );
-            })}
-            <Field className="msab-margin-top">
-              <Label className="msab-has-text-grey" htmlFor="image">
-                Location Image (optional - max size 1 MB)
-              </Label>
-              <Subtitle className="msab-has-text-grey-small">
-                Please choose an image less than 1MB in size and within the file
-                types supported: GIF, JPG/JPEG, PNG
-              </Subtitle>
-              <Control>
-                <input
-                  id="image"
-                  name="image"
-                  type="file"
-                  onChange={e => {
-                    setImageSequence({
-                      image: e.target.files[0],
-                    });
-                  }}
-                />
-              </Control>
-              {form.imageURL && !form.base64Image && (
-                <Control>
-                  <img src={form.imageURL} />
-                </Control>
               )}
-            </Field>
-            {imgFailure && (
-              <Notification isColor="danger">{imgMsg}</Notification>
-            )}
-            <br />
-            <Title className="msab-has-text-purple" isSize={4}>
-              Contact Information
-            </Title>
-            <Subtitle className="msab-has-text-grey" isSize={5}>
-              (For internal use only, won’t be published on site)
-            </Subtitle>
-            <Field>
-              <Label className="msab-has-text-grey" htmlFor="contactName">
-                Contact Name
-              </Label>
-              <Control className="text-field">
-                <Input
-                  id="contactName"
-                  name="contactName"
-                  type="text"
-                  value={form.contactName || ''}
-                  onChange={e => {
-                    updateFormValueSequence({
-                      key: e.target.name,
-                      value: e.target.value,
-                    });
-                  }}
-                />
-              </Control>
-            </Field>
-            <Field>
-              <Label className="msab-has-text-grey" htmlFor="contactEmail">
-                Contact E-mail
-              </Label>
-              <Control className="text-field">
-                <Input
-                  id="contactEmail"
-                  name="contactEmail"
-                  type="text"
-                  value={form.contactEmail || ''}
-                  onChange={e => {
-                    updateFormValueSequence({
-                      key: e.target.name,
-                      value: e.target.value,
-                    });
-                  }}
-                />
-              </Control>
-            </Field>
-            <Field>
-              <Label className="msab-has-text-grey" htmlFor="contactPhone">
-                Contact Phone
-              </Label>
-              <Control className="text-field">
-                <Input
-                  id="contactPhone"
-                  name="contactPhone"
-                  type="text"
-                  value={form.contactPhone || ''}
-                  onChange={e => {
-                    updateFormValueSequence({
-                      key: e.target.name,
-                      value: e.target.value,
-                    });
-                  }}
-                />
-              </Control>
-            </Field>
-            {locationFormButtonsHelper.showSubmit && (
-              <Field>
+              <Field isGrouped>
                 <Control>
-                  <Checkbox
-                    id="tos"
-                    name="ToS"
-                    onChange={e => {
+                  <ReCAPTCHA
+                    className="msab-margin-top"
+                    sitekey={RECAPTCHA_KEY}
+                    onChange={value => {
                       updateFormValueSequence({
-                        key: 'ToS',
-                        value: e.target.checked,
+                        key: 'gresp',
+                        value,
                       });
                     }}
-                  >
-                    <span className="msab-has-text-grey margin-left-10">
-                      I agree to the{' '}
-                      <a href="tos" target="_blank">
-                        terms of service
-                      </a>
-                    </span>
-                  </Checkbox>
-                </Control>
-              </Field>
-            )}
-            <Field isGrouped>
-              <Control>
-                <ReCAPTCHA
-                  className="msab-margin-top"
-                  sitekey={RECAPTCHA_KEY}
-                  onChange={value => {
-                    updateFormValueSequence({
-                      key: 'gresp',
-                      value,
-                    });
-                  }}
-                  onExpired={() => {
-                    updateFormValueSequence({
-                      key: 'gresp',
-                      value: '',
-                    });
-                  }}
-                />
-              </Control>
-            </Field>
-            {locationFormButtonsHelper.showAdmin && (
-              <Field>
-                <Control>
-                  <Checkbox
-                    checked={form.approved || false}
-                    id="approved"
-                    name="approved"
-                    onChange={e => {
+                    onExpired={() => {
                       updateFormValueSequence({
-                        key: 'approved',
-                        value: e.target.checked,
+                        key: 'gresp',
+                        value: '',
                       });
                     }}
-                  >
-                    <span className="msab-has-text-grey margin-left-10">
-                      Approved for publish
-                    </span>
-                  </Checkbox>
+                  />
                 </Control>
               </Field>
-            )}
-            <Field isGrouped>
-              <Control>
-                <Button
-                  className="msab-margin-top msab-margin-lr"
-                  isColor="primary"
-                  type="button"
-                  onClick={() => {
-                    cancelLocationInput();
-                  }}
-                >
-                  Cancel
-                </Button>
-                {locationFormButtonsHelper.showAdmin && (
+              {locationFormButtonsHelper.showAdmin && (
+                <Field>
+                  <Control>
+                    <Checkbox
+                      checked={form.approved || false}
+                      id="approved"
+                      name="approved"
+                      onChange={e => {
+                        updateFormValueSequence({
+                          key: 'approved',
+                          value: e.target.checked,
+                        });
+                      }}
+                    >
+                      <span className="msab-has-text-grey margin-left-10">
+                        Approved for publish
+                      </span>
+                    </Checkbox>
+                  </Control>
+                </Field>
+              )}
+              <Field isGrouped>
+                <Control>
                   <Button
-                    className="msab-margin-top"
+                    className="msab-margin-top msab-margin-lr"
                     isColor="primary"
-                    type="submit"
-                    onClick={e => {
-                      onSubmit(e);
+                    type="button"
+                    onClick={() => {
+                      cancelLocationInput();
                     }}
                   >
-                    Save
+                    Cancel
                   </Button>
-                )}
-                {locationFormButtonsHelper.showSubmit && (
-                  <Button
-                    className="msab-margin-top"
-                    disabled={!form.ToS}
-                    isColor="primary"
-                    type="submit"
-                    onClick={e => {
-                      onSubmit(e);
-                    }}
-                  >
-                    Submit
-                  </Button>
-                )}
+                  {locationFormButtonsHelper.showAdmin && (
+                    <Button
+                      className="msab-margin-top"
+                      isColor="primary"
+                      type="submit"
+                      onClick={e => {
+                        onSubmit(e);
+                      }}
+                    >
+                      Save
+                    </Button>
+                  )}
+                  {locationFormButtonsHelper.showSubmit && (
+                    <Button
+                      className="msab-margin-top"
+                      disabled={!form.ToS}
+                      isColor="primary"
+                      type="submit"
+                      onClick={e => {
+                        onSubmit(e);
+                      }}
+                    >
+                      Submit
+                    </Button>
+                  )}
 
-                {locationFormButtonsHelper.showUpdate && (
-                  <Button
-                    className="msab-margin-top"
-                    disabled={!form.formDirty}
-                    isColor="primary"
-                    type="submit"
-                    onClick={e => {
-                      onSubmit(e);
-                    }}
-                  >
-                    Update
-                  </Button>
-                )}
-              </Control>
-            </Field>
-          </form>
-        </Container>
-      </Section>
+                  {locationFormButtonsHelper.showUpdate && (
+                    <Button
+                      className="msab-margin-top"
+                      disabled={!form.formDirty}
+                      isColor="primary"
+                      type="submit"
+                      onClick={e => {
+                        onSubmit(e);
+                      }}
+                    >
+                      Update
+                    </Button>
+                  )}
+                </Control>
+              </Field>
+            </form>
+          </Container>
+        </Section>
+      </Container>
     );
   },
 );

--- a/src/views/LocationListItem.jsx
+++ b/src/views/LocationListItem.jsx
@@ -21,7 +21,7 @@ export const LocationListItem = ({
   setActiveFilter,
 }) => {
   return (
-    <React.Fragment>
+    <>
       <div>
         <a
           className="has-text-primary location-name"
@@ -88,6 +88,6 @@ export const LocationListItem = ({
           </Tag>
         ))}
       </div>
-    </React.Fragment>
+    </>
   );
 };

--- a/src/views/LocationListItem.jsx
+++ b/src/views/LocationListItem.jsx
@@ -76,10 +76,10 @@ export const LocationListItem = ({
         </MediaContent>
       </Media>
       <div className="msab-location-media">
-        {location.categories.map((tag, i) => (
+        {location.categories.map(tag => (
           <Tag
             className="msab-has-background-teal msab-has-text-grey tag-text msab-margin-10 msab-pointer"
-            key={i}
+            key={tag}
             onClick={() => {
               setActiveFilter({ value: tag });
             }}

--- a/src/views/Main.jsx
+++ b/src/views/Main.jsx
@@ -25,7 +25,7 @@ export const Main = connect(
     let CurrentPage = pages[currentPage];
     let isActive = findingLocations || askingLocation || gettingLocation;
     return (
-      <React.Fragment>
+      <>
         <main id="main-content" role="main">
           {/* {currentPage === 'Home' && ( */}
           <Loading
@@ -37,7 +37,7 @@ export const Main = connect(
           {/* )} */}
           <CurrentPage />
         </main>
-      </React.Fragment>
+      </>
     );
   },
 );

--- a/src/views/ResultsList.jsx
+++ b/src/views/ResultsList.jsx
@@ -35,11 +35,11 @@ class ResultsListComponent extends React.Component {
       <Section>
         <Container>
           {!!locations.length && (
-            <React.Fragment>
+            <>
               <Level className="msab-has-background-grey msab-filter">
                 {!activeFilter && 'Click on a Category Tag to Filter'}
                 {activeFilter && (
-                  <React.Fragment>
+                  <>
                     <Level isMobile>
                       <LevelLeft>
                         <LevelItem>
@@ -60,7 +60,7 @@ class ResultsListComponent extends React.Component {
                         </LevelItem>
                       </LevelRight>
                     </Level>
-                  </React.Fragment>
+                  </>
                 )}
               </Level>
               <Level isMobile>
@@ -95,7 +95,7 @@ class ResultsListComponent extends React.Component {
                   )}
                 </LevelRight>
               </Level>
-            </React.Fragment>
+            </>
           )}
           <ul>
             {locations.map((location, i) => (

--- a/src/views/ResultsList.jsx
+++ b/src/views/ResultsList.jsx
@@ -99,7 +99,7 @@ class ResultsListComponent extends React.Component {
           )}
           <ul>
             {locations.map((location, i) => (
-              <li key={i}>
+              <li key={location.name}>
                 <LocationListItem
                   categories={categories}
                   citySearch={citySearch}

--- a/src/views/TOS.jsx
+++ b/src/views/TOS.jsx
@@ -4,7 +4,7 @@ import { Foot } from './Footer';
 import React from 'react';
 
 export const TOS = () => (
-  <React.Fragment>
+  <>
     <AppHeader />
 
     <Section>
@@ -311,5 +311,5 @@ export const TOS = () => (
       </Container>
     </Section>
     <Foot />
-  </React.Fragment>
+  </>
 );

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -1772,9 +1772,9 @@
     semver "^6.1.1"
 
 "@serverless/dashboard-plugin@^5.4.0":
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/@serverless/dashboard-plugin/-/dashboard-plugin-5.4.1.tgz#50e3387824bd299556c925cc8becda0818d18549"
-  integrity sha512-lOj6jJIzZEPfiaMi70HNWD2uFd8+hzfAArsprtDvsek2H+1JSQ8I4vCtlLOf/X0hQn3sIHI7JQizathkzXkBrg==
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/@serverless/dashboard-plugin/-/dashboard-plugin-5.4.2.tgz#afad1ce3a38d6563cb3d57d8122f9a9906178ebf"
+  integrity sha512-yFugs3TBPjZh6Gt/8lPca8H7n2/ICin17r/zmhiOhIscYMgIJT1EOY9EyCFWIQi9AMAmZD0a3ZR8U8gSYYTT9A==
   dependencies:
     "@serverless/event-mocks" "^1.1.1"
     "@serverless/platform-client" "^4.2.3"
@@ -3253,9 +3253,9 @@ aws4@^1.8.0:
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
 axe-core@^4.0.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.2.2.tgz#0c987d82c8b82b4b9b7a945f1b5ef0d8fed586ed"
-  integrity sha512-OKRkKM4ojMEZRJ5UNJHmq9tht7cEnRnqKG6KyB/trYws00Xtkv12mHtlJ0SK7cmuNbrU8dPUova3ELTuilfBbw==
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.2.3.tgz#2a3afc332f0031b42f602f4a3de03c211ca98f72"
+  integrity sha512-pXnVMfJKSIWU2Ml4JHP7pZEPIrgBO1Fd3WGx+fPBsS+KRGhE4vxooD8XBGWbQOIVSZsVK7pUDBBkCicNu80yzQ==
 
 axios@^0.21.1:
   version "0.21.1"
@@ -4441,21 +4441,6 @@ concat-stream@~1.6.0:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-concurrently@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-6.2.0.tgz#587e2cb8afca7234172d8ea55176088632c4c56d"
-  integrity sha512-v9I4Y3wFoXCSY2L73yYgwA9ESrQMpRn80jMcqMgHx720Hecz2GZAvTI6bREVST6lkddNypDKRN22qhK0X8Y00g==
-  dependencies:
-    chalk "^4.1.0"
-    date-fns "^2.16.1"
-    lodash "^4.17.21"
-    read-pkg "^5.2.0"
-    rxjs "^6.6.3"
-    spawn-command "^0.0.2-1"
-    supports-color "^8.1.0"
-    tree-kill "^1.2.2"
-    yargs "^16.2.0"
-
 configstore@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/configstore/-/configstore-5.0.1.tgz#d365021b5df4b98cdd187d6a3b0e3f6a7cc5ed96"
@@ -4536,22 +4521,22 @@ copy-descriptor@^0.1.0:
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
 core-js-compat@^3.14.0, core-js-compat@^3.15.0:
-  version "3.15.0"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.15.0.tgz#e14a371123db9d1c5b41206d3f420643d238b8fa"
-  integrity sha512-8X6lWsG+s7IfOKzV93a7fRYfWRZobOfjw5V5rrq43Vh/W+V6qYxl7Akalsvgab4PFT/4L/pjQbdBUEM36NXKrw==
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.15.1.tgz#1afe233716d37ee021956ef097594071b2b585a7"
+  integrity sha512-xGhzYMX6y7oEGQGAJmP2TmtBLvR4nZmRGEcFa3ubHOq5YEp51gGN9AovVa0AoujGZIq+Wm6dISiYyGNfdflYww==
   dependencies:
     browserslist "^4.16.6"
     semver "7.0.0"
 
 core-js-pure@^3.15.0:
-  version "3.15.0"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.15.0.tgz#c19349ae0be197b8bcf304acf4d91c5e29ae2091"
-  integrity sha512-RO+LFAso8DB6OeBX9BAcEGvyth36QtxYon1OyVsITNVtSKr/Hos0BXZwnsOJ7o+O6KHtK+O+cJIEj9NGg6VwFA==
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.15.1.tgz#8356f6576fa2aa8e54ca6fe02620968ff010eed7"
+  integrity sha512-OZuWHDlYcIda8sJLY4Ec6nWq2hRjlyCqCZ+jCflyleMkVt3tPedDVErvHslyS2nbO+SlBFMSBJYvtLMwxnrzjA==
 
-core-js@3.15.0:
-  version "3.15.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.15.0.tgz#db9554ebce0b6fd90dc9b1f2465c841d2d055044"
-  integrity sha512-GUbtPllXMYRzIgHNZ4dTYTcUemls2cni83Q4Q/TrFONHfhcg9oEGOtaGHfb0cpzec60P96UKPvMkjX1jET8rUw==
+core-js@3.15.1:
+  version "3.15.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.15.1.tgz#6c08ab88abdf56545045ccf5fd81f47f407e7f1a"
+  integrity sha512-h8VbZYnc9pDzueiS2610IULDkpFFPunHwIpl8yRwFahAEEdSpHlTy3h3z3rKq5h11CaUdBEeRViu9AYvbxiMeg==
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -4926,11 +4911,6 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-date-fns@^2.16.1:
-  version "2.22.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
-  integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
-
 dateformat@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.2.tgz#9a4df4bff158ac2f34bc637abdb15471607e1659"
@@ -4991,9 +4971,9 @@ decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.1.2, decamelize@^1.2.0:
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
 decimal.js@^10.2.1:
-  version "10.2.1"
-  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.1.tgz#238ae7b0f0c793d3e3cea410108b35a2c01426a3"
-  integrity sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.3.0.tgz#96fd481189818e0d5810c18ac147824b9e4c0026"
+  integrity sha512-MrQRs2gyD//7NeHi9TtsfClkf+cFAewDz+PZHR8ILKglLmBMyVX3ymQ+oeznE3tjrS7beTN+6JXb2C3JDHm7ug==
 
 decimal.js@^6.0.0:
   version "6.0.0"
@@ -5435,9 +5415,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.723:
-  version "1.3.754"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.754.tgz#afbe69177ad7aae968c3bbeba129dc70dcc37cf4"
-  integrity sha512-Q50dJbfYYRtwK3G9mFP/EsJVzlgcYwKxFjbXmvVa1lDAbdviPcT9QOpFoufDApub4j0hBfDRL6v3lWNLEdEDXQ==
+  version "1.3.755"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.755.tgz#4b6101f13de910cf3f0a1789ddc57328133b9332"
+  integrity sha512-BJ1s/kuUuOeo1bF/EM2E4yqW9te0Hpof3wgwBx40AWJE18zsD1Tqo0kr7ijnOc+lRsrlrqKPauJAHqaxOItoUA==
 
 elliptic@^6.5.3:
   version "6.5.4"
@@ -12482,7 +12462,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^6.4.0, rxjs@^6.6.0, rxjs@^6.6.2, rxjs@^6.6.3:
+rxjs@^6.4.0, rxjs@^6.6.0, rxjs@^6.6.2:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -13080,11 +13060,6 @@ source-map@^0.7.3, source-map@~0.7.2:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
-spawn-command@^0.0.2-1:
-  version "0.0.2-1"
-  resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
-  integrity sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=
-
 spdx-correct@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.1.tgz#dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9"
@@ -13636,7 +13611,7 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^8.0.0, supports-color@^8.1.0:
+supports-color@^8.0.0:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -14017,11 +13992,6 @@ traverse@^0.6.6:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
   integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=
-
-tree-kill@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
-  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
 trim-newlines@^1.0.0:
   version "1.0.0"
@@ -14958,7 +14928,7 @@ yargs@^13.3.2:
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
 
-yargs@^16.0.0, yargs@^16.0.3, yargs@^16.2.0:
+yargs@^16.0.0, yargs@^16.0.3:
   version "16.2.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
   integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==


### PR DESCRIPTION
Addresses tasks in #172.

Rejiggered a few things with handling success & failure feedback, per #173.

* Errors & successes now use the light-teal background
* Errors will appear above the form, and will scroll to top to make them visible
* All error details (when multiple are available) will display in a bulleted list
* Success will route back to `Home` view
* Success & Errors now have a main message (larger) and a detail message (smaller)

Example success message:
<img width="302" alt="image" src="https://user-images.githubusercontent.com/444571/123338738-fca71980-d50e-11eb-89bc-6df98838d6be.png">

Example error message:
<img width="301" alt="image" src="https://user-images.githubusercontent.com/444571/123338745-00d33700-d50f-11eb-9bcc-169241cd889e.png">
