### PR TITLE
Add strict handling of node version.

### DIFF
--- a/src/.npmrc
+++ b/src/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "msab-art-locator-client",
-  "version": "0.0.1",
+  "version": "1.1.0",
   "private": true,
   "description": "Front end client for MSAB mobile Arts Locator application.",
   "homepage": "https://github.com/flexion/msab-arts-locator#readme",
@@ -14,6 +14,7 @@
   "license": "MIT",
   "author": "Flexion Inc.",
   "main": "index.dev.js",
+  "engines" : { "node" : ">=14.0.0" },
   "scripts": {
     "debug": "node --inspect-brk node_modules/.bin/jest --runInBand .*test\\.js$",
     "fix": "prettier --write",


### PR DESCRIPTION
* Throw error if the wrong version of Node is available.

Node version should match (minimum) what is used in Lambda runtime (currently nodejs14.x).