### PR TITLE
Parameterize Google `client` ReCAPTCHA key.

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -390,9 +390,11 @@ Here's the details.
       - `AWS_TLS_CERTIFICATE_ID` (whatever you setup before, looks like a GUID)
       - `EMAIL_USERNAME` (used to configure the email gateway)
       - `EMAIL_PASSWORD` (used to configure the email gateway)
-      - `GOOGLE_CAPTCHA_KEY` (whatever you saved from the reCAPTCHA setup before)
+      - `GOOGLE_SERVER_RECAPTCHA_KEY` (whatever you saved from the reCAPTCHA setup before)
+      - `GOOGLE_CLIENT_RECAPTCHA_KEY`
       - `GOOGLE_GEOCODING_API_KEY` (whatever you saved from the geocoder setup before)
       - `STAGE` (the namespace for this job to deploy to, e.g. `staging` or `live` or anything you want it to be)
+      - `LAMBDA_EXECUTION_ROLE_ARN` (the ARN of the _lambda execution_ role you setup previously)
 - Buildspec
   - (Select) Use a buildspec file
 - No artifacts or batch configuration (skip)

--- a/src/config/defaults.yml
+++ b/src/config/defaults.yml
@@ -1,0 +1,7 @@
+domainNameRoot: ${env:DOMAIN_NAME_ROOT}
+certificateId: ${env:AWS_TLS_CERTIFICATE_ID}
+googleGeocodingApiKey: ${env:GOOGLE_GEOCODING_API_KEY}
+googleCaptchaKey: ${env:GOOGLE_SERVER_RECAPTCHA_KEY}
+emailUsername: ${env:EMAIL_USERNAME}
+emailPassword: ${env:EMAIL_PASSWORD}
+lambdaExecutionRole: ${env:LAMBDA_EXECUTION_ROLE_ARN}

--- a/src/package.json
+++ b/src/package.json
@@ -33,10 +33,11 @@
     "lint:fix": "eslint --fix . && eslint --fix ./**/*.jsx && stylelint --fix ./**/*.scss",
     "offline": "yarn sls offline --stage local",
     "checkAwsEnv": "node utilities/get-caller-identity.js",
-    "start": "rm -rf dist && npm-run-all -p watch-css start-js offline",
+    "start": "yarn setClientReCAPTCHAKey && rm -rf dist && npm-run-all -p watch-css start-js offline",
     "start-js": "yarn codeVersion && yarn checkAwsEnv && MSAB_ENV=dev node run-localServer.js",
     "codeVersion": "cp -v release_info.js environments/client/version.js || echo \"module.exports = { version: '$(git describe --tags)' };\" > environments/client/version.js",
-    "build": "yarn codeVersion && MSAB_ENV=prod parcel build  --no-source-maps index.pug"
+    "setClientReCAPTCHAKey": "if [[ ! -z \"$GOOGLE_CLIENT_RECAPTCHA_KEY\" ]]; then echo \"module.exports = { RECAPTCHA_KEY: '$GOOGLE_CLIENT_RECAPTCHA_KEY' };\" > config/config.js && echo \"Updated client config.js\"; else echo \"No GOOGLE_CLIENT_RECAPTCHA_KEY var set, not updating client config.js\"; fi",
+    "build": "yarn setClientReCAPTCHAKey && yarn codeVersion && MSAB_ENV=prod parcel build  --no-source-maps index.pug"
   },
   "resolutions": {
     "qs": "^6.3.2",

--- a/src/serverless.yml
+++ b/src/serverless.yml
@@ -6,7 +6,7 @@ plugins:
   - serverless-offline
 
 custom:
-  vars: ${file(./config/${opt:stage}.yml)}
+  vars: ${file(./config/${opt:stage, 'defaults'}.yml)}
   domain: ${opt:stage}.${self:custom.vars.domainNameRoot}
   region: ${opt:region, 'us-east-2'}
   certificateId: ${self:custom.vars.certificateId} # Required by AWS to be in us-east-1
@@ -61,7 +61,7 @@ provider:
 
   iam:
     role: ${self:custom.vars.lambdaExecutionRole}
-  lambdaHashingVersion: "20201221"
+  lambdaHashingVersion: '20201221'
 
 package:
   patterns:
@@ -143,9 +143,9 @@ resources:
       Properties:
         DistributionConfig:
           Origins:
-          - Id: WebApp
-            DomainName:
-              Fn::GetAtt: [WebAppS3Bucket, RegionalDomainName]
+            - Id: WebApp
+              DomainName:
+                Fn::GetAtt: [WebAppS3Bucket, RegionalDomainName]
     LoggingBucket:
       Type: AWS::S3::Bucket
       Properties:
@@ -159,14 +159,14 @@ resources:
       Properties:
         Bucket: !Ref ImagesBucket
         PolicyDocument:
-          Version: "2012-10-17"
-          Statement: 
+          Version: '2012-10-17'
+          Statement:
             - Effect: Allow
-              Action: 
-                - "s3:GetObject"
-              Resource: 
+              Action:
+                - 's3:GetObject'
+              Resource:
                 - !Join ['', ['arn:aws:s3:::', !Ref ImagesBucket, '/*']]
-              Principal: "*"
+              Principal: '*'
     GisTable:
       Type: AWS::DynamoDB::Table
       Properties:


### PR DESCRIPTION
Added a new script in `package.json` to generate the `configs/config.js` if the env var `GOOGLE_CLIENT_RECAPTCHA_KEY` is set. This is used by the React client code at runtime (bundled by parcel).

* Also create 'defaults' config `.yml` that looks to ENV vars for all configs.
  * This allows _lambda execution role_ ARN to be specified completely as env var
  * Stage-specific `.yml` config files are still supported for backwards compatibility in current deployments.
* Updated _Getting Started_ docs to reflect additional env var setup for **CodeBuild**.