### PR TITLE
Refactor externalized configs to use `dotenv`.

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -60,7 +60,7 @@ Access http://www.google.com/recaptcha/admin to setup a key pair (client/server)
 
 Submit
 
-You'll receive two keys - a client-side key and a server-side secret. The client-side key is encoded in the React client code (see `src/config/config.js`), the server-side secret is provided in the serverless environment config (see `config/example.yml`).
+You'll receive two keys - a client-side key and a server-side secret. The client-side key is encoded in the React client code (see `src/config/config.js`), the server-side secret is provided in the serverless environment config (see `src/.env`).
 
 ## AWS Setup
 

--- a/README.md
+++ b/README.md
@@ -31,27 +31,29 @@ Basically, if you can run commands like `aws s3 ls`, then you should be in good 
 ## GOOGLE Access
 
 To use the various google apis, you will need to get api keys for:
+
 - [ ] Google reCAPTCHA - https://developers.google.com/recaptcha/intro
 - [ ] Google Maps - https://developers.google.com/maps/documentation/geocoding/start
 
 The environment variables for these keys are:
-* GOOGLE_CAPTCHA_KEY (server-side secret)
-* GOOGLE_GEOCODING_API_KEY
+
+- GOOGLE_CAPTCHA_KEY (server-side secret)
+- GOOGLE_GEOCODING_API_KEY
 
 ### reCAPTCHA
 
-Access http://www.google.com/recaptcha/admin to setup a key pair (client/server). You'll _Register a new site_, providing 
+Access http://www.google.com/recaptcha/admin to setup a key pair (client/server). You'll _Register a new site_, providing
 
 1. Label: anything you want, site URL is a good option if it's descriptive enough
 2. reCAPTCHA type: v2
-3. Domains: the domains the reCAPTCHA will be served from (base domain should suffice, e.g. msab.flexion.us should enable *.msab.flexion.us)
+3. Domains: the domains the reCAPTCHA will be served from (base domain should suffice, e.g. msab.flexion.us should enable \*.msab.flexion.us)
 4. Owners: email addresses/accounts that can administer
 5. Accept the reCAPTCH TOS
 6. Send alerts to owners: optional
 
 Submit
 
-You'll receive two keys - a client-side key and a server-side secret. The client-side key is encoded in the React client code (see `src/config/config.js`), the server-side secret is provided in the serverless environment config (see `config/example.yml`).
+You'll receive two keys - a client-side key and a server-side secret. The client-side key is encoded in the React client code (see `src/config/config.js`), the server-side secret is provided in the serverless environment config (see `src/.env`).
 
 ## Prerequisites
 

--- a/src/.env.dev
+++ b/src/.env.dev
@@ -1,0 +1,7 @@
+domainNameRoot=${DOMAIN_NAME_ROOT}
+certificateId=${AWS_TLS_CERTIFICATE_ID}
+googleGeocodingApiKey=${GOOGLE_GEOCODING_API_KEY}
+googleCaptchaKey=${GOOGLE_CAPTCHA_KEY}
+emailUsername=${EMAIL_USERNAME}
+emailPassword=${EMAIL_PASSWORD}
+lambdaExecutionRole='!Sub arn:aws:iam::\${AWS::AccountId}:role/msab-arts-locator-lambdaExecutionRole'

--- a/src/.env.local
+++ b/src/.env.local
@@ -1,0 +1,9 @@
+certificateId=""
+domainNameRoot=""
+emailGateway="dummy"
+emailUsername=""
+emailPassword=""
+googleGeocodingApiKey=${GOOGLE_GEOCODING_API_KEY}
+googleCaptchaKey=""
+googleCaptchaGateway="noop"
+lambdaExecutionRole=""

--- a/src/.env.qa
+++ b/src/.env.qa
@@ -1,0 +1,7 @@
+domainNameRoot=${DOMAIN_NAME_ROOT}
+certificateId=${AWS_TLS_CERTIFICATE_ID}
+googleGeocodingApiKey=${GOOGLE_GEOCODING_API_KEY}
+googleCaptchaKey=${GOOGLE_CAPTCHA_KEY}
+emailUsername=${EMAIL_USERNAME}
+emailPassword=${EMAIL_PASSWORD}
+lambdaExecutionRole='!Sub arn:aws:iam::\${AWS::AccountId}:role/msab-arts-locator-lambdaExecutionRole'

--- a/src/README.md
+++ b/src/README.md
@@ -260,7 +260,8 @@ The `deployer` (above) policy has no `IAM` permissions to create the Lambda exec
 }
 ```
 
-Update the `dev.yml` configuration with the ARN of the role created above.
+Update the `.env.dev` configuration with the ARN of the role created above.
+
 ## Fullstack / web-app client
 
 This project leverages `nodejs14.x` and the `fullstack-serverless` plugin to deploy the single-page client app in `client/`.

--- a/src/config/defaults.yml
+++ b/src/config/defaults.yml
@@ -1,7 +1,0 @@
-domainNameRoot: ${env:DOMAIN_NAME_ROOT}
-certificateId: ${env:AWS_TLS_CERTIFICATE_ID}
-googleGeocodingApiKey: ${env:GOOGLE_GEOCODING_API_KEY}
-googleCaptchaKey: ${env:GOOGLE_SERVER_RECAPTCHA_KEY}
-emailUsername: ${env:EMAIL_USERNAME}
-emailPassword: ${env:EMAIL_PASSWORD}
-lambdaExecutionRole: ${env:LAMBDA_EXECUTION_ROLE_ARN}

--- a/src/config/dev.yml
+++ b/src/config/dev.yml
@@ -1,7 +1,0 @@
-domainNameRoot: ${env:DOMAIN_NAME_ROOT}
-certificateId: ${env:AWS_TLS_CERTIFICATE_ID}
-googleGeocodingApiKey: ${env:GOOGLE_GEOCODING_API_KEY}
-googleCaptchaKey: ${env:GOOGLE_CAPTCHA_KEY}
-emailUsername: ${env:EMAIL_USERNAME}
-emailPassword: ${env:EMAIL_PASSWORD}
-lambdaExecutionRole: !Sub arn:aws:iam::${AWS::AccountId}:role/msab-arts-locator-lambdaExecutionRole

--- a/src/config/example.yml
+++ b/src/config/example.yml
@@ -1,8 +1,0 @@
-domainNameRoot: subdomain.domain.us
-# certificate `Identifier` from AWS Certificate Manager, not the ARN
-certificateId: xxxxxxxx-yyyy-zzzz-aaaa-123456789012
-googleGeocodingApiKey: ""
-googleCaptchaKey: ""
-emailUsername: ""
-emailPassword: ""
-lambdaExecutionRole: arn:aws:iam::<account-id>:role/your-externally-created-lambdaRole

--- a/src/config/local.yml
+++ b/src/config/local.yml
@@ -1,9 +1,0 @@
-certificateId: .
-domainNameRoot: .
-emailGateway: dummy
-emailUsername: .
-emailPassword: .
-googleGeocodingApiKey: ${env:GOOGLE_GEOCODING_API_KEY}
-googleCaptchaKey: .
-googleCaptchaGateway: noop
-lambdaExecutionRole: .

--- a/src/config/qa.yml
+++ b/src/config/qa.yml
@@ -1,7 +1,0 @@
-domainNameRoot: ${env:DOMAIN_NAME_ROOT}
-certificateId: ${env:AWS_TLS_CERTIFICATE_ID}
-googleGeocodingApiKey: ${env:GOOGLE_GEOCODING_API_KEY}
-googleCaptchaKey: ${env:GOOGLE_CAPTCHA_KEY}
-emailUsername: ${env:EMAIL_USERNAME}
-emailPassword: ${env:EMAIL_PASSWORD}
-lambdaExecutionRole: !Sub arn:aws:iam::${AWS::AccountId}:role/msab-arts-locator-lambdaExecutionRole

--- a/src/serverless.yml
+++ b/src/serverless.yml
@@ -5,19 +5,19 @@ plugins:
   - serverless-stack-output
   - serverless-offline
 
+useDotenv: true
 custom:
-  vars: ${file(./config/${opt:stage, 'defaults'}.yml)}
-  domain: ${opt:stage}.${self:custom.vars.domainNameRoot}
+  domain: ${opt:stage}.${env:domainNameRoot}
   region: ${opt:region, 'us-east-2'}
-  certificateId: ${self:custom.vars.certificateId} # Required by AWS to be in us-east-1
-  apiKey: ${self:custom.vars.googleGeocodingApiKey} #api key to use google maps api
-  captchaKey: ${self:custom.vars.googleCaptchaKey, ''}
-  captchaGateway: ${self:custom.vars.googleCaptchaGateway, ''}
+  certificateId: ${env:certificateId} # Required by AWS to be in us-east-1
+  apiKey: ${env:googleGeocodingApiKey} #api key to use google maps api
+  captchaKey: ${env:googleCaptchaKey, ''}
+  captchaGateway: ${env:googleCaptchaGateway, ''}
   imageBucket: ${self:service}-${opt:stage}-images
   loggingBucket: ${self:service}-${opt:stage}-logs
-  emailGateway: ${self:custom.vars.emailGateway, 'gmail'}
-  emailUser: ${self:custom.vars.emailUsername}
-  emailPW: ${self:custom.vars.emailPassword}
+  emailGateway: ${env:emailGateway, 'gmail'}
+  emailUser: ${env:emailUsername}
+  emailPW: ${env:emailPassword}
 
   output:
     file: .serverless/stack.json
@@ -60,7 +60,7 @@ provider:
   region: ${self:custom.region}
 
   iam:
-    role: ${self:custom.vars.lambdaExecutionRole}
+    role: ${env:lambdaExecutionRole}
   lambdaHashingVersion: '20201221'
 
 package:


### PR DESCRIPTION
* Removed loading of custom vars `.yml` file
* Enabled `useDotenv` (will be standard in an upcoming Serverless Framework release)
* Created default `.env` file that references documented ENV vars
* Converted [dev|qa].yml files to corresponding `.env.dev` and `.env.qa` files

This setup allows for a dual-abstracted externalization. You can specify all parameters via the environment AND you can override certain configs by specifying stage-specific `.env.<stage>` files.